### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,4 +25,4 @@ repository:
   # description: ""
 
   # Use a comma-separated list of topics to set on the repo (ensure not to use any caps in the topic string).
-  topics: terraform, ibm-cloud, deployable-architecture
+  topics: terraform, ibm-cloud, deployable-architecture, core-team

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -112,7 +112,8 @@
             {
               "key": "use_existing_resource_group"
             }
-          ]
+          ],
+          "terraform_version": "1.10.5"
         },
         {
           "label": "Static website configurator",
@@ -174,7 +175,8 @@
             {
               "key": "index_document"
             }
-          ]
+          ],
+          "terraform_version": "1.10.5"
         }
       ]
     }


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        